### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/bootstrap/js/bootstrap.bundle.js
+++ b/vendor/bootstrap/js/bootstrap.bundle.js
@@ -1073,7 +1073,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/apnavp/Portfolio/security/code-scanning/5](https://github.com/apnavp/Portfolio/security/code-scanning/5)

General fix: never pass untrusted string data to jQuery’s `$()` constructor. Use DOM selector APIs (`document.querySelector`) and then wrap the resulting element with jQuery if needed.

Best minimal fix here (without changing behavior): in `vendor/bootstrap/js/bootstrap.bundle.js`, replace line using `$(selector)[0]` in `Carousel._dataApiClickHandler` with `document.querySelector(selector)`. This keeps selector semantics, avoids jQuery HTML interpretation, and aligns with existing `Util.getSelectorFromElement` validation logic.

Needed changes:
- File: `vendor/bootstrap/js/bootstrap.bundle.js`
- Region: `Carousel._dataApiClickHandler`, around line 1076
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
